### PR TITLE
Remove miniconda role from requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -9,8 +9,6 @@ roles:
     version: 1.1.2
   - src: galaxyproject.postgresql_objects
     version: 1.2.0
-  - src: galaxyproject.miniconda
-    version: 0.3.1
   - src: geerlingguy.docker
     version: 6.1.0
 


### PR DESCRIPTION
This role is only required to install Galaxy itself using a conda env.